### PR TITLE
[feat] 각 엔티티별로 BaseEntity 상속 적용 및 JpaConfig 구현 

### DIFF
--- a/src/main/java/com/ll/jsbwtl/config/JpaConfig.java
+++ b/src/main/java/com/ll/jsbwtl/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.ll.jsbwtl.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/ll/jsbwtl/domain/answer/entity/Answer.java
+++ b/src/main/java/com/ll/jsbwtl/domain/answer/entity/Answer.java
@@ -1,22 +1,18 @@
 package com.ll.jsbwtl.domain.answer.entity;
 
+import com.ll.jsbwtl.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 // 예시 코드입니다. (지우시고 자유롭게 개발하셔도 돼요)
 @Entity
 @Getter
 @Setter
-public class Answer {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Answer extends BaseEntity {
     private String content;
 }
 

--- a/src/main/java/com/ll/jsbwtl/domain/catagory/entity/Category.java
+++ b/src/main/java/com/ll/jsbwtl/domain/catagory/entity/Category.java
@@ -1,23 +1,18 @@
 package com.ll.jsbwtl.domain.catagory.entity;
 
+import com.ll.jsbwtl.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 
 // 예시 코드입니다. (지우시고 자유롭게 개발하셔도 돼요)
 @Entity
 @Getter
 @Setter
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Category extends BaseEntity {
     private String content;
 }
 

--- a/src/main/java/com/ll/jsbwtl/domain/comment/entity/Comment.java
+++ b/src/main/java/com/ll/jsbwtl/domain/comment/entity/Comment.java
@@ -1,21 +1,17 @@
 package com.ll.jsbwtl.domain.comment.entity;
 
+import com.ll.jsbwtl.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 // 예시 코드입니다. (지우시고 자유롭게 개발하셔도 돼요)
 @Entity
 @Getter
 @Setter
-public class Comment {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
     private String content;
 }

--- a/src/main/java/com/ll/jsbwtl/domain/question/entity/Question.java
+++ b/src/main/java/com/ll/jsbwtl/domain/question/entity/Question.java
@@ -1,21 +1,17 @@
 package com.ll.jsbwtl.domain.question.entity;
 
+import com.ll.jsbwtl.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 // 예시 코드입니다. (지우시고 자유롭게 개발하셔도 돼요)
 @Entity
 @Getter
 @Setter
-public class Question {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question extends BaseEntity {
     private String content;
 }

--- a/src/main/java/com/ll/jsbwtl/domain/user/entity/User.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/entity/User.java
@@ -1,7 +1,10 @@
 package com.ll.jsbwtl.domain.user.entity;
 
+import com.ll.jsbwtl.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -10,13 +13,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
-public class User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class User extends BaseEntity {
     @Column(nullable = false, unique = true, length = 30)
     private String username;
 

--- a/src/main/java/com/ll/jsbwtl/global/jpa/entity/BaseEntity.java
+++ b/src/main/java/com/ll/jsbwtl/global/jpa/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.ll.jsbwtl.global.jpa.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #1 

## 📝 작업 내용

> 각 엔티티별로 모두 사용하는 id,createDate(생성일),updatedDate(수정일)을 따로 BaseEntity로 빼서 구현 한 후, 모든곳에 상속으로 적용시켰습니다.
생성일,수정일을 사용하기 위해서 필요한 JpaConfig를 구현하였습니다.

## 🖼️ 스크린샷 (선택)

> X

## 💬 리뷰 요구사항 (선택)

> X