### PR TITLE
[Feat] 소셜 로그인 성공시 jwt토큰 생성 및 로컬스토리지에 저장 구현

### DIFF
--- a/src/main/java/com/ll/jsbwtl/config/SecurityConfig.java
+++ b/src/main/java/com/ll/jsbwtl/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.ll.jsbwtl.config;
 import com.ll.jsbwtl.config.jwt.JwtAuthenticationFilter;
 import com.ll.jsbwtl.config.jwt.JwtTokenProvider;
 import com.ll.jsbwtl.domain.user.service.CustomOAuth2UserService;
+import com.ll.jsbwtl.domain.user.service.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
@@ -20,6 +22,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -29,6 +32,7 @@ public class SecurityConfig {
     // Spring Security 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
         http
                 // JWT 사용 시 세션을 사용하지 않기 때문에 STATELESS 설정
                 .csrf(csrf -> csrf.disable())
@@ -46,7 +50,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
-                        .defaultSuccessUrl("/question/list", true) // 여기에 직접 명시
+                        .successHandler(oAuth2SuccessHandler) // 로그인 성공 시 JWT 발급
                 )
                 // JWT 인증 필터 등록
                 .addFilterBefore(

--- a/src/main/java/com/ll/jsbwtl/config/SecurityConfig.java
+++ b/src/main/java/com/ll/jsbwtl/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 // 요청 URL 별로 인증/인가 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/", "/login", "/signup",
+                                "/", "/login", "/signup","/login/success",
                                 "/css/**", "/js/**", "/images/**",
                                 "/question/**", "/answer/**", "/user/**"
                         ).permitAll()

--- a/src/main/java/com/ll/jsbwtl/domain/user/controller/UserController.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/controller/UserController.java
@@ -1,8 +1,14 @@
 package com.ll.jsbwtl.domain.user.controller;
 
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Map;
 
 // 예시 코드입니다. (지우시고 자유롭게 개발하셔도 돼요)
 @Controller
@@ -11,5 +17,12 @@ public class UserController {
     @GetMapping("/login")
     public String loginPage() {
         return "user/login"; // templates/login.html 로 이동
+    }
+
+    @GetMapping("/login/success")
+    public String successPage(HttpServletRequest request, Model model) {
+        String accessToken = (String) request.getSession().getAttribute("accessToken");
+        model.addAttribute("accessToken", accessToken);
+        return "user/login-success"; // user/login-success.html
     }
 }

--- a/src/main/java/com/ll/jsbwtl/domain/user/controller/UserController.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.Map;
@@ -20,9 +21,9 @@ public class UserController {
     }
 
     @GetMapping("/login/success")
-    public String successPage(HttpServletRequest request, Model model) {
-        String accessToken = (String) request.getSession().getAttribute("accessToken");
-        model.addAttribute("accessToken", accessToken);
+    public String successPage(@RequestParam String token, Model model) {
+        model.addAttribute("accessToken", token);
         return "user/login-success"; // user/login-success.html
     }
+
 }

--- a/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
@@ -1,0 +1,58 @@
+package com.ll.jsbwtl.domain.user.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.jsbwtl.config.jwt.JwtTokenProvider;
+import com.ll.jsbwtl.global.oauth.OAuth2Attrs;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws ServletException, IOException {
+        // 1. OAuth2User 정보 가져오기
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+        Long localUserId = ((Number) Objects.requireNonNull(oAuth2User.getAttribute("localUserId"))).longValue();
+        String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
+
+        // 2. JWT Access Token 발급
+        String accessToken = jwtTokenProvider.generateToken(localUserId, role);
+
+        // 3. JSON 형태로 응답 (쿠키 대신)
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("accessToken", accessToken);
+        responseBody.put("userId", localUserId);
+        responseBody.put("username", oAuth2User.getAttribute("username"));
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+
+    //쿠키 사용 방식
+//        Cookie cookie = new Cookie("accessToken", accessToken);
+//        cookie.setHttpOnly(true);
+//        cookie.setPath("/");
+//        response.addCookie(cookie);
+//
+//        response.sendRedirect("/question/list");
+    }
+}
+

--- a/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
@@ -30,8 +30,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         Long localUserId = ((Number) oAuth2User.getAttribute("localUserId")).longValue();
         String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
 
+
         // JWT 발급
         String accessToken = jwtTokenProvider.generateToken(localUserId, role);
+
+        //System.out.println("accessToken : " + accessToken);
 
         response.sendRedirect("/login/success?token=" + accessToken);
     }

--- a/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ll/jsbwtl/domain/user/service/OAuth2SuccessHandler.java
@@ -2,9 +2,7 @@ package com.ll.jsbwtl.domain.user.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.jsbwtl.config.jwt.JwtTokenProvider;
-import com.ll.jsbwtl.global.oauth.OAuth2Attrs;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,36 +21,20 @@ import java.util.Objects;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws ServletException, IOException {
-        // 1. OAuth2User 정보 가져오기
+                                        Authentication authentication) throws IOException, ServletException {
         DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
-        Long localUserId = ((Number) Objects.requireNonNull(oAuth2User.getAttribute("localUserId"))).longValue();
+        Long localUserId = ((Number) oAuth2User.getAttribute("localUserId")).longValue();
         String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
 
-        // 2. JWT Access Token 발급
+        // JWT 발급
         String accessToken = jwtTokenProvider.generateToken(localUserId, role);
 
-        // 3. JSON 형태로 응답 (쿠키 대신)
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("accessToken", accessToken);
-        responseBody.put("userId", localUserId);
-        responseBody.put("username", oAuth2User.getAttribute("username"));
-
-        response.setContentType("application/json; charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
-
-    //쿠키 사용 방식
-//        Cookie cookie = new Cookie("accessToken", accessToken);
-//        cookie.setHttpOnly(true);
-//        cookie.setPath("/");
-//        response.addCookie(cookie);
-//
-//        response.sendRedirect("/question/list");
+        response.sendRedirect("/login/success?token=" + accessToken);
     }
 }
+
 

--- a/src/main/resources/templates/user/login-success.html
+++ b/src/main/resources/templates/user/login-success.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 처리 중...</title>
+</head>
+<body>
+<h2>로그인 처리 중입니다...</h2>
+
+<p>로그인 성공! 🎉</p>
+<p>Access Token: <span th:text="${accessToken}"></span></p>
+
+<script th:inline="javascript">
+    const token = /*[[${accessToken}]]*/ "";
+    if (token) {
+        localStorage.setItem("accessToken", token);
+
+        //window.location.href = "/";
+    }
+</script>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/user/login-success.html
+++ b/src/main/resources/templates/user/login-success.html
@@ -14,7 +14,6 @@
     const token = /*[[${accessToken}]]*/ "";
     if (token) {
         localStorage.setItem("accessToken", token);
-
         //window.location.href = "/";
     }
 </script>


### PR DESCRIPTION

## 📝 작업 내용

> 소셜 로그인 성공시 jwt토큰 생성하여 프론트에서 로컬스토리지에 저장하게 하였습니다.
로그인 성공 페이지는 임시로 만들었습니다.

<img width="1266" height="309" alt="image" src="https://github.com/user-attachments/assets/cc9054d8-8036-47e0-b5d5-83d6723c262f" />

<img width="2251" height="612" alt="image" src="https://github.com/user-attachments/assets/6fab1460-5f33-4bc7-85aa-4c41d9aa5f12" />


