### PR TITLE
[fix] 답변 관련 경로 불일치 및 답변 수정 기능 오류 해결 

### DIFF
--- a/src/main/java/com/ll/jsbwtl/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/ll/jsbwtl/domain/answer/controller/AnswerController.java
@@ -91,7 +91,7 @@ public class AnswerController {
         Answer answer = answerService.getById(id);
         requireOwner(auth, answer);
         Long questionId = answerService.update(id, content, auth.getName());
-        return "redirect:/question/detail/%s".formatted(questionId);
+        return "redirect:/questions/%s".formatted(questionId);
     }
 
 

--- a/src/main/java/com/ll/jsbwtl/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/ll/jsbwtl/domain/answer/service/AnswerService.java
@@ -5,6 +5,7 @@ import com.ll.jsbwtl.domain.answer.repository.AnswerRepository;
 import com.ll.jsbwtl.domain.question.entity.Question;
 import com.ll.jsbwtl.domain.user.entity.User;
 import com.ll.jsbwtl.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +41,7 @@ public class AnswerService {
         return answer.getQuestion().getId();
     }
 
+    @Transactional
     public Long update(Long id, String content, String username) {
         Answer answer = getById(id);
         requireOwner(answer, username);

--- a/src/main/resources/templates/answer/modify.html
+++ b/src/main/resources/templates/answer/modify.html
@@ -15,7 +15,7 @@
 
 <h1>답변 수정</h1>
 
-<form th:action="@{|/answer/update/${answer.id}|}" method="post">
+<form th:action="@{|/questions/update/${answer.id}|}" method="post">
     <textarea name="content" rows="8" th:text="${answer.content}"></textarea>
     <div>
         <button type="submit">수정 완료</button>

--- a/src/main/resources/templates/question/detail.html
+++ b/src/main/resources/templates/question/detail.html
@@ -111,7 +111,9 @@
                 <span th:text="${a.author.nickname}">작성자</span>
                 <span th:text="${#temporals.format(a.createdAt,'yyyy.MM.dd HH:mm')}">날짜</span>
             </div>
-            <div class="content" th:utext="${a.contentHtml}">답변 내용</div>
+            <a th:href="@{|/questions/update/${a.id}|}" style="text-decoration: none; color: inherit;">
+                <div class="content" th:utext="${a.contentHtml}">답변 내용</div>
+            </a>
         </div>
     </section>
 

--- a/src/main/resources/templates/user/login-success.html
+++ b/src/main/resources/templates/user/login-success.html
@@ -9,11 +9,13 @@
 
 <p>로그인 성공! 🎉</p>
 
+<a href="/questions">질문 목록으로 이동</a>
+
 <script th:inline="javascript">
     const token = /*[[${accessToken}]]*/ "";
     if (token) {
         localStorage.setItem("accessToken", token);
-        //window.location.href = "/";
+        // window.location.href = "/questions";
     }
 </script>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 답변쪽에서 경로 불일치로 대부분의 경로가 로그인 페이지로 감 -> 경로 맞춰줘서 해결
> 본인이 작성한 답변에 대해서 해당 답변 누르고 수정하면 수정 안됨 -> 서비스 update 부분에 @Transaction 추가하여 오류 해결 
> 소셜로그인 성공 후에 질문 목록 페이지로 갈 수 있도록 이동 태그 추가 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요